### PR TITLE
Fix Config library type

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -40,7 +40,7 @@ export declare interface Config {
   baseMs?: number;
   delayMs?: number;
   maxRetries?: number;
-  library ?: pg.Client;
+  library?: pg;
 }
 
 declare class ServerlessClient {


### PR DESCRIPTION
The value expected in the `library` property is the export of `pg` rather than a `Client` constructor