### PR TITLE
Add support for importing with nodenext

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,14 +1,14 @@
 import stream = require('stream');
 import pg = require('pg');
 
-export declare interface TlsOptions {
+declare interface TlsOptions {
   rejectUnauthorized?: boolean;
   ca?: string;
   key?: string;
   cert?: string;
 }
 
-export declare interface Config {
+declare interface Config {
   user?: string;
   database?: string;
   password?: string | (() => string | Promise<string>);
@@ -40,7 +40,11 @@ export declare interface Config {
   baseMs?: number;
   delayMs?: number;
   maxRetries?: number;
-  library ?: pg.Client;
+  library?: pg.Client;
+}
+
+declare namespace ServerlessClient {
+  export { TlsOptions, Config }
 }
 
 declare class ServerlessClient {
@@ -53,4 +57,4 @@ declare class ServerlessClient {
   on(...args): void
 }
 
-export default ServerlessClient
+export = ServerlessClient

--- a/package.json
+++ b/package.json
@@ -3,6 +3,7 @@
   "version": "0.0.0-development",
   "description": "",
   "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "test": "docker-compose up --build -d && jest && docker-compose down",
     "semantic-release": "semantic-release"
@@ -22,7 +23,6 @@
     "@babel/helper-environment-visitor": "^7.16.7",
     "@babel/helper-hoist-variables": "^7.16.7"
   },
-  "typings": "index.d.ts",
   "prettier": {
     "printWidth": 100
   },


### PR DESCRIPTION
Importing this module with `nodenext` now fails due to `es6` syntax being used in the types.
I reverted to using `export = ...` syntax, and added the remaining type exports using a namespace.
This should fix the module to be imported in all module systems.