### PR TITLE
fix(retry-logic): Include timeout errors in retry logic

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -407,7 +407,8 @@ ServerlessClient.prototype.connect = async function () {
     if (
       e.message === "sorry, too many clients already" ||
       e.message === "Connection terminated unexpectedly" ||
-      e.message === "terminating connection due to administrator command"
+      e.message === "terminating connection due to administrator command" ||
+      e.message === "timeout expired"
     ) {
       this._client = null
       // Client in node-pg is usable only one time, once it errors we cannot re-connect again,


### PR DESCRIPTION
When a connection times out, it doesn't seem like the library retries. Looking into the code, it seems like we're not accounting for the timeout error that `node-postgres` outputs.

String from `node-postgres` can be found [here](https://github.com/brianc/node-postgres/blob/master/packages/pg/lib/client.js#L105).