### PR TITLE
fix(types): align new esm imports

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -39,7 +39,7 @@ declare interface Config {
   baseMs?: number;
   delayMs?: number;
   maxRetries?: number;
-  library?: typeof import("pg");
+  library?: typeof import("pg").default;
   plugin?: Plugin;
 }
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,12 +9,13 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "pg": "^8.11.5"
+        "pg": "^8.15.6"
       },
       "devDependencies": {
         "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-environment-visitor": "^7.22.20",
         "@babel/helper-hoist-variables": "^7.22.5",
+        "@types/pg": "^8.15.0",
         "aws-xray-sdk": "^3.6.0",
         "husky": "^4.3.8",
         "jest": "^26.6.3",
@@ -1599,10 +1600,11 @@
       "dev": true
     },
     "node_modules/@types/pg": {
-      "version": "8.11.5",
-      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.11.5.tgz",
-      "integrity": "sha512-2xMjVviMxneZHDHX5p5S6tsRRs7TpDHeeK7kTTMe/kAC/mRRNjWHjZg0rkiY+e17jXSZV3zJYDxXV8Cy72/Vuw==",
+      "version": "8.15.0",
+      "resolved": "https://registry.npmjs.org/@types/pg/-/pg-8.15.0.tgz",
+      "integrity": "sha512-JFxVIO0hZCbQXQGbRBQjbRWNCG3CujfEUBD4Ny2l0QqDyE0vqAPiMSyx0AIszMS0KdLZxz2GxZUUF3FBUXhOXA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "@types/node": "*",
         "pg-protocol": "*",
@@ -9505,13 +9507,14 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.11.5",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.11.5.tgz",
-      "integrity": "sha512-jqgNHSKL5cbDjFlHyYsCXmQDrfIX/3RsNwYqpd4N0Kt8niLuNoRNH+aazv6cOd43gPh9Y4DjQCtb+X0MH0Hvnw==",
+      "version": "8.15.6",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.15.6.tgz",
+      "integrity": "sha512-yvao7YI3GdmmrslNVsZgx9PfntfWrnXwtR+K/DjI0I/sTKif4Z623um+sjVZ1hk5670B+ODjvHDAckKdjmPTsg==",
+      "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.6.4",
-        "pg-pool": "^3.6.2",
-        "pg-protocol": "^1.6.1",
+        "pg-connection-string": "^2.8.5",
+        "pg-pool": "^3.9.6",
+        "pg-protocol": "^1.9.5",
         "pg-types": "^2.1.0",
         "pgpass": "1.x"
       },
@@ -9519,7 +9522,7 @@
         "node": ">= 8.0.0"
       },
       "optionalDependencies": {
-        "pg-cloudflare": "^1.1.1"
+        "pg-cloudflare": "^1.2.5"
       },
       "peerDependencies": {
         "pg-native": ">=3.0.1"
@@ -9531,15 +9534,17 @@
       }
     },
     "node_modules/pg-cloudflare": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.1.1.tgz",
-      "integrity": "sha512-xWPagP/4B6BgFO+EKz3JONXv3YDgvkbVrGw2mTo3D6tVDQRh1e7cqVGvyR3BE+eQgAvx1XhW/iEASj4/jCWl3Q==",
+      "version": "1.2.5",
+      "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.5.tgz",
+      "integrity": "sha512-OOX22Vt0vOSRrdoUPKJ8Wi2OpE/o/h9T8X1s4qSkCedbNah9ei2W2765be8iMVxQUsvgT7zIAT2eIa9fs5+vtg==",
+      "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.6.4",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.6.4.tgz",
-      "integrity": "sha512-v+Z7W/0EO707aNMaAEfiGnGL9sxxumwLl2fJvCQtMn9Fxsg+lPpPkdcyBSv/KFgpGdYkMfn+EI1Or2EHjpgLCA=="
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.8.5.tgz",
+      "integrity": "sha512-Ni8FuZ8yAF+sWZzojvtLE2b03cqjO5jNULcHFfM9ZZ0/JXrgom5pBREbtnAw7oxsxJqHw9Nz/XWORUEL3/IFow==",
+      "license": "MIT"
     },
     "node_modules/pg-cursor": {
       "version": "2.10.5",
@@ -9568,17 +9573,19 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.6.2",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.6.2.tgz",
-      "integrity": "sha512-Htjbg8BlwXqSBQ9V8Vjtc+vzf/6fVUuak/3/XXKA9oxZprwW3IMDQTGHP+KDmVL7rtd+R1QjbnCFPuTHm3G4hg==",
+      "version": "3.9.6",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.9.6.tgz",
+      "integrity": "sha512-rFen0G7adh1YmgvrmE5IPIqbb+IgEzENUm+tzm6MLLDSlPRoZVhzU1WdML9PV2W5GOdRA9qBKURlbt1OsXOsPw==",
+      "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.6.1",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.6.1.tgz",
-      "integrity": "sha512-jPIlvgoD63hrEuihvIg+tJhoGjUsLPn6poJY9N5CnlPd91c2T18T/9zBtLxZSb1EhYxBRoZJtzScCaWlYLtktg=="
+      "version": "1.9.5",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.9.5.tgz",
+      "integrity": "sha512-DYTWtWpfd5FOro3UnAfwvhD8jh59r2ig8bPtc9H8Ds7MscE/9NYruUQWFAOuraRl29jwcT2kyMFQ3MxeaVjUhg==",
+      "license": "MIT"
     },
     "node_modules/pg-query-stream": {
       "version": "4.5.5",

--- a/package.json
+++ b/package.json
@@ -12,12 +12,13 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "pg": "^8.11.5"
+    "pg": "^8.15.6"
   },
   "devDependencies": {
     "@babel/helper-compilation-targets": "^7.23.6",
     "@babel/helper-environment-visitor": "^7.22.20",
     "@babel/helper-hoist-variables": "^7.22.5",
+    "@types/pg": "^8.15.0",
     "aws-xray-sdk": "^3.6.0",
     "husky": "^4.3.8",
     "jest": "^26.6.3",


### PR DESCRIPTION
The [latest versions](https://github.com/brianc/node-postgres/blob/master/CHANGELOG.md#pg8150) of `pg` added esm named exports to the package. This makes the type of library here incompatible. The solution is to use the default export from the new types (https://github.com/DefinitelyTyped/DefinitelyTyped/pull/72649).