### PR TITLE
feat: make ServerlessClient EventEmitter

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,4 +1,6 @@
+import EventEmitter = require("events");
 import stream = require("stream");
+import pg = require("pg");
 
 declare interface TlsOptions {
   rejectUnauthorized?: boolean;
@@ -75,7 +77,7 @@ declare namespace ServerlessClient {
   export { TlsOptions, Config };
 }
 
-declare class ServerlessClient {
+declare class ServerlessClient extends EventEmitter {
   constructor(config: Config)
 
   clean(): Promise<number | undefined>
@@ -88,7 +90,7 @@ declare class ServerlessClient {
 
   end(): Promise<any>
 
-  on(...args): void
+  on(event: "init", listener: (client: pg.Client) => void): this
 }
 
 export = ServerlessClient

--- a/package-lock.json
+++ b/package-lock.json
@@ -1579,12 +1579,13 @@
       }
     },
     "node_modules/@types/node": {
-      "version": "20.12.7",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-20.12.7.tgz",
-      "integrity": "sha512-wq0cICSkRLVaf3UGLMGItu/PtdY7oaXaI/RVU+xliKVOtRna3PRY57ZDfztpDL0n11vfymMUnXv8QwYCO7L1wg==",
+      "version": "22.15.17",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-22.15.17.tgz",
+      "integrity": "sha512-wIX2aSZL5FE+MR0JlvF87BNVrtFWf6AE6rxSE9X7OwnVvoyCQjpzSRJ+M87se/4QCkCiebQAqrJ0y6fwIyi7nw==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
-        "undici-types": "~5.26.4"
+        "undici-types": "~6.21.0"
       }
     },
     "node_modules/@types/normalize-package-data": {
@@ -12141,10 +12142,11 @@
       }
     },
     "node_modules/undici-types": {
-      "version": "5.26.5",
-      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-5.26.5.tgz",
-      "integrity": "sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==",
-      "dev": true
+      "version": "6.21.0",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
+      "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/union-value": {
       "version": "1.0.1",

--- a/src/index.js
+++ b/src/index.js
@@ -6,10 +6,13 @@
  * @license MIT
  */
 
+const EventEmitter = require("events");
 const {isValidStrategy, type, validateNum, isWithinRange} = require("./utils");
 const Postgres = require("./postgres");
 
 function ServerlessClient(config) {
+  EventEmitter.call(this);
+
   this._client = null;
   if (config.plugin) {
     this._plugin = config.plugin
@@ -19,6 +22,9 @@ function ServerlessClient(config) {
 
   this.setConfig(config)
 }
+
+ServerlessClient.prototype = Object.create(EventEmitter.prototype);
+ServerlessClient.prototype.constructor = ServerlessClient;
 
 ServerlessClient.prototype.constructor = ServerlessClient;
 ServerlessClient.prototype._sleep = delay =>
@@ -201,6 +207,7 @@ ServerlessClient.prototype._init = async function () {
     await this._setMaxConnections(this)
   }
 
+  this.emit("init", this._client);
   this._logger("Max connections: ", this._maxConns.cache.total)
 }
 
@@ -421,10 +428,6 @@ ServerlessClient.prototype.end = async function () {
   this._backoff.queryRetries = 0
   await this._client.end()
   this._client = null
-}
-
-ServerlessClient.prototype.on = function (...args) {
-  this._client.on(...args)
 }
 
 module.exports = {ServerlessClient};


### PR DESCRIPTION
I've been running this patch locally for a while.
It is technically a breaking change, because `.on` would stop attaching events directly to the internal client...
But I think this is an important change, because otherwise we don't have any way to be notified of when a client is initiated.
I think another problem with the old approach is that, if the `_client` gets refreshed at any point during the runtime, for example, by calling `end`, the events attached to it would disappear.

The way this issue is solved with this PR would be:

```
        client.on("init", (client) => {
            client.on("error", logger.error.bind(logger));
            client.on("notice", logger.info.bind(logger, "notice: "));
            client.on("notification", logger.info.bind(logger, "notification: "));
            client.on("end", logger.info.bind(logger, "end: "));
            client.on("drain", logger.info.bind(logger, "drain: "));
        });
```

With this method, if `end` and `connect` are called, the events will be reattached to the new client