### PR TITLE
feat!: make pg a peer dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ Feel free to request additional features and contribute =)
 ## Install
 
 ```bash
-npm i serverless-postgres
+npm i serverless-postgres pg
 ```
 
 ## Usage
@@ -159,7 +159,7 @@ You can then use your plugin like this:
 | Property                 | Type                | Description                                                                                                                                                | Default             | Version |
 |--------------------------|---------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------------|---------|
 | config                   | `Object`            | A `node-pg` configuration object as defined [here](https://node-postgres.com/api/client)                                                                   | `{}`                |         |
-| maxConnsFreqMs           | `Integer`           | The number of milliseconds to cache lookups of max_connections.                                                                                            | `60000`             |         |
+| maxConnsFreqMs           | `Integer`           | The number of milliseconds to cache lookups of max\_connections.                                                                                            | `60000`             |         |
 | manualMaxConnections     | `Boolean`           | if this parameters is set to true it will query to get the maxConnections values, to maximize performance you should set the `maxConnections` yourself     | `false`             |         |
 | maxConnections           | `Integer`           | Max connections of your PostgreSQL, it should be set equal to `max_connections` in your cluster. I highly suggest to set this yourself                     | `100`               |         |
 | strategy                 | `String`            | Name of your chosen strategy for cleaning up "zombie" connections, allowed values `minimum_idle_time` or `ranked`                                          | `minimum_idle_time` |         |
@@ -175,11 +175,5 @@ You can then use your plugin like this:
 | processCountFreqMs       | `Integer`           | The number of milliseconds to cache lookups of process count.                                                                                              | `6000`              |         |
 | allowCredentialsDiffing  | `Boolean`           | If you are using dynamic credentials, such as IAM, you can set this parameter to `true` and the client will be refreshed                                   | `false`             |         |
 | library                  | `Function`          | Custom postgres library                                                                                                                                    | `require('pg')`     |         |
-| application_name         | `String`            | This is postgres specific configuration; serverless-pg uses it to avoid closing other applications connections.                                            | `serverless_client` | `>= v2` |
+| application\_name         | `String`            | This is postgres specific configuration; serverless-pg uses it to avoid closing other applications connections.                                            | `serverless_client` | `>= v2` |
 | plugin                   | `Object`            | This is where you need to initialize your plugin class                                                                                                     | `Postgres`          | `>= v2` |
-
-## Note
-
-- `Serverless-postgres` depends on `pg` package and usually you **do not need to install it on your own**.
-  As some users have observed, if you have installed it on your own, and it is a different version,
-  this package might misbehave.

--- a/package-lock.json
+++ b/package-lock.json
@@ -8,9 +8,6 @@
       "name": "serverless-postgres",
       "version": "0.0.0-development",
       "license": "MIT",
-      "dependencies": {
-        "pg": "^8.15.6"
-      },
       "devDependencies": {
         "@babel/helper-compilation-targets": "^7.23.6",
         "@babel/helper-environment-visitor": "^7.22.20",
@@ -19,9 +16,18 @@
         "aws-xray-sdk": "^3.6.0",
         "husky": "^4.3.8",
         "jest": "^26.6.3",
+        "pg": "^8.16.0",
         "pg-query-stream": "^4.5.5",
         "prettier": "^1.19.1",
         "semantic-release": "^19.0.5"
+      },
+      "peerDependencies": {
+        "pg": "^8"
+      },
+      "peerDependenciesMeta": {
+        "pg": {
+          "optional": true
+        }
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -9507,16 +9513,17 @@
       }
     },
     "node_modules/pg": {
-      "version": "8.15.6",
-      "resolved": "https://registry.npmjs.org/pg/-/pg-8.15.6.tgz",
-      "integrity": "sha512-yvao7YI3GdmmrslNVsZgx9PfntfWrnXwtR+K/DjI0I/sTKif4Z623um+sjVZ1hk5670B+ODjvHDAckKdjmPTsg==",
+      "version": "8.16.0",
+      "resolved": "https://registry.npmjs.org/pg/-/pg-8.16.0.tgz",
+      "integrity": "sha512-7SKfdvP8CTNXjMUzfcVTaI+TDzBEeaUnVwiVGZQD1Hh33Kpev7liQba9uLd4CfN8r9mCVsD0JIpq03+Unpz+kg==",
+      "dev": true,
       "license": "MIT",
       "dependencies": {
-        "pg-connection-string": "^2.8.5",
-        "pg-pool": "^3.9.6",
-        "pg-protocol": "^1.9.5",
-        "pg-types": "^2.1.0",
-        "pgpass": "1.x"
+        "pg-connection-string": "^2.9.0",
+        "pg-pool": "^3.10.0",
+        "pg-protocol": "^1.10.0",
+        "pg-types": "2.2.0",
+        "pgpass": "1.0.5"
       },
       "engines": {
         "node": ">= 8.0.0"
@@ -9537,13 +9544,15 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/pg-cloudflare/-/pg-cloudflare-1.2.5.tgz",
       "integrity": "sha512-OOX22Vt0vOSRrdoUPKJ8Wi2OpE/o/h9T8X1s4qSkCedbNah9ei2W2765be8iMVxQUsvgT7zIAT2eIa9fs5+vtg==",
+      "dev": true,
       "license": "MIT",
       "optional": true
     },
     "node_modules/pg-connection-string": {
-      "version": "2.8.5",
-      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.8.5.tgz",
-      "integrity": "sha512-Ni8FuZ8yAF+sWZzojvtLE2b03cqjO5jNULcHFfM9ZZ0/JXrgom5pBREbtnAw7oxsxJqHw9Nz/XWORUEL3/IFow==",
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/pg-connection-string/-/pg-connection-string-2.9.0.tgz",
+      "integrity": "sha512-P2DEBKuvh5RClafLngkAuGe9OUlFV7ebu8w1kmaaOgPcpJd1RIFh7otETfI6hAR8YupOLFTY7nuvvIn7PLciUQ==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg-cursor": {
@@ -9559,6 +9568,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/pg-int8/-/pg-int8-1.0.1.tgz",
       "integrity": "sha512-WCtabS6t3c8SkpDBUlb1kjOs7l66xsGdKpIPZsg4wR+B3+u9UAum2odSsF9tnvxg80h4ZxLWMy4pRjOsFIqQpw==",
+      "dev": true,
       "engines": {
         "node": ">=4.0.0"
       }
@@ -9573,18 +9583,20 @@
       }
     },
     "node_modules/pg-pool": {
-      "version": "3.9.6",
-      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.9.6.tgz",
-      "integrity": "sha512-rFen0G7adh1YmgvrmE5IPIqbb+IgEzENUm+tzm6MLLDSlPRoZVhzU1WdML9PV2W5GOdRA9qBKURlbt1OsXOsPw==",
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/pg-pool/-/pg-pool-3.10.0.tgz",
+      "integrity": "sha512-DzZ26On4sQ0KmqnO34muPcmKbhrjmyiO4lCCR0VwEd7MjmiKf5NTg/6+apUEu0NF7ESa37CGzFxH513CoUmWnA==",
+      "dev": true,
       "license": "MIT",
       "peerDependencies": {
         "pg": ">=8.0"
       }
     },
     "node_modules/pg-protocol": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.9.5.tgz",
-      "integrity": "sha512-DYTWtWpfd5FOro3UnAfwvhD8jh59r2ig8bPtc9H8Ds7MscE/9NYruUQWFAOuraRl29jwcT2kyMFQ3MxeaVjUhg==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/pg-protocol/-/pg-protocol-1.10.0.tgz",
+      "integrity": "sha512-IpdytjudNuLv8nhlHs/UrVBhU0e78J0oIS/0AVdTbWxSOkFUVdsHC/NrorO6nXsQNDTT1kzDSOMJubBQviX18Q==",
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/pg-query-stream": {
@@ -9621,6 +9633,7 @@
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/pg-types/-/pg-types-2.2.0.tgz",
       "integrity": "sha512-qTAAlrEsl8s4OiEQY69wDvcMIdQN6wdz5ojQiOy6YRMuynxenON0O5oCpJI6lshc6scgAY8qvJ2On/p+CXY0GA==",
+      "dev": true,
       "dependencies": {
         "pg-int8": "1.0.1",
         "postgres-array": "~2.0.0",
@@ -9636,6 +9649,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/postgres-array/-/postgres-array-2.0.0.tgz",
       "integrity": "sha512-VpZrUqU5A69eQyW2c5CA1jtLecCsN2U/bD6VilrFDWq5+5UIEVO7nazS3TEcHf1zuPYO/sqGvUvW62g86RXZuA==",
+      "dev": true,
       "engines": {
         "node": ">=4"
       }
@@ -9644,6 +9658,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/postgres-bytea/-/postgres-bytea-1.0.0.tgz",
       "integrity": "sha512-xy3pmLuQqRBZBXDULy7KbaitYqLcmxigw14Q5sj8QBVLqEwXfeybIKVWiqAXTlcvdvb0+xkOtDbfQMOf4lST1w==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9652,6 +9667,7 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/postgres-date/-/postgres-date-1.0.7.tgz",
       "integrity": "sha512-suDmjLVQg78nMK2UZ454hAG+OAW+HQPZ6n++TNDUX+L0+uUlLywnoxJKDou51Zm+zTCjrCl0Nq6J9C5hP9vK/Q==",
+      "dev": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9660,6 +9676,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/postgres-interval/-/postgres-interval-1.2.0.tgz",
       "integrity": "sha512-9ZhXKM/rw350N1ovuWHbGxnGh/SNJ4cnxHiM0rxE4VN41wsg8P8zWn9hv/buK00RP4WvlOyr/RBDiptyxVbkZQ==",
+      "dev": true,
       "dependencies": {
         "xtend": "^4.0.0"
       },
@@ -9671,6 +9688,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/pgpass/-/pgpass-1.0.5.tgz",
       "integrity": "sha512-FdW9r/jQZhSeohs1Z3sI1yxFQNFvMcnmfuj4WBMUTxOrAyLMaTcE1aAMBiTlbMNaXvBCQuVi0R7hd8udDSP7ug==",
+      "dev": true,
       "dependencies": {
         "split2": "^4.1.0"
       }
@@ -11468,6 +11486,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/split2/-/split2-4.2.0.tgz",
       "integrity": "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==",
+      "dev": true,
       "engines": {
         "node": ">= 10.x"
       }
@@ -12565,6 +12584,7 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
+      "dev": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/package.json
+++ b/package.json
@@ -11,8 +11,13 @@
   },
   "author": "",
   "license": "MIT",
-  "dependencies": {
-    "pg": "^8.15.6"
+  "peerDependencies": {
+    "pg": "^8"
+  },
+  "peerDependenciesMeta": {
+    "pg": {
+      "optional": true
+    }
   },
   "devDependencies": {
     "@babel/helper-compilation-targets": "^7.23.6",
@@ -22,6 +27,7 @@
     "aws-xray-sdk": "^3.6.0",
     "husky": "^4.3.8",
     "jest": "^26.6.3",
+    "pg": "^8.16.0",
     "pg-query-stream": "^4.5.5",
     "prettier": "^1.19.1",
     "semantic-release": "^19.0.5"


### PR DESCRIPTION
`pg` is not strictly required by this package - `require("pg")` is only called when the library option is not specified.
I think it makes more sense to declare `pg` an optional peer dependency.
What do you think?